### PR TITLE
Feature/pgpsupport

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ As you can see the 'users' hash was merged this time while now the 'repos' array
 
 
 
-You can althoug work with encrypted dicts. If a value is PGP encrypted, varstack can decrypt this value if it is encrypted with one of your public keys.
+You can also work with encrypted dicts. If a value is PGP encrypted, varstack can decrypt this value if it is encrypted with one of your public keys.
 
 ```
 ---
@@ -216,7 +216,7 @@ enc_data: |
 pip install python-gnupg
 ```
 
-Packageinfo :[https://pythonhosted.org/python-gnupg/](https://pythonhosted.org/python-gnupg/)
+Packageinfo: [https://pythonhosted.org/python-gnupg/](https://pythonhosted.org/python-gnupg/)
 
 Inside this encrypted value, dicts and lists can exist. This will be parsed through varstack, too.
 

--- a/README.md
+++ b/README.md
@@ -193,3 +193,38 @@ users:
 
 As you can see the 'users' hash was merged this time while now the 'repos' array/list only contains the entry from the node file.
 
+
+
+You can althoug work with encrypted dicts. If a value is PGP encrypted, varstack can decrypt this value if it is encrypted with one of your public keys.
+
+```
+---
+enc_data: |
+  -----BEGIN PGP MESSAGE-----
+  
+  P1eDjfxWvGFIkKpzgZi7rafqsGSlhXUDvTIcXoopCMABZkycUWQw99TM8QlXrk44
+  Svk7CUar...                 ...40aAfYwYS49T7PyfuPnQ0zVVieVjvNO+2
+  /eQU3e+ipxKRND8UtSf9jvBIXDcqQUkuubAPHV7WHswb2OoaPm3QFLraPaXoxPR1
+  VLglxg==
+  =+fch
+  -----END PGP MESSAGE-----
+```
+
+**Importent!** For this feature you have to install python-gnupg
+
+```
+pip install python-gnupg
+```
+
+Packageinfo :[https://pythonhosted.org/python-gnupg/](https://pythonhosted.org/python-gnupg/)
+
+Inside this encrypted value, dicts and lists can exist. This will be parsed through varstack, too.
+
+**Importent!** encrypted values can not be nested, so you can not encrypt a dict, put it in another dict and encrypt this.
+=> Only the lasted cipher will be decrypted.
+
+The default gnupgdir is '_$HOME/.gnupg_'. If you want to chose another path, put _gnupghome: PATH_TO_GNUPG_FOLDER_ inside your varstack.yaml config file
+
+
+
+

--- a/README.md
+++ b/README.md
@@ -220,9 +220,6 @@ Packageinfo :[https://pythonhosted.org/python-gnupg/](https://pythonhosted.org/p
 
 Inside this encrypted value, dicts and lists can exist. This will be parsed through varstack, too.
 
-**Importent!** encrypted values can not be nested, so you can not encrypt a dict, put it in another dict and encrypt this.
-=> Only the lasted cipher will be decrypted.
-
 The default gnupgdir is '_$HOME/.gnupg_'. If you want to chose another path, put _gnupghome: PATH_TO_GNUPG_FOLDER_ inside your varstack.yaml config file
 
 

--- a/varstack/__init__.py
+++ b/varstack/__init__.py
@@ -99,6 +99,9 @@ class Varstack:
 
     """Merge two configuration sets."""
     def __mergeData(self, old, new, combine, keyname):
+        for key in new:
+            new[key] = self.__check_enc(new[key])
+
         if type(old) != type(new):
             self.log.error('key "{0}": previous type is {1} but new type is {2}.'.format(keyname, type(old).__name__, type(new).__name__))
             return False
@@ -137,3 +140,22 @@ class Varstack:
                 return old+new
         else:
             return new
+
+    def __check_enc(self, value):
+        if '---BEGIN PGP MESSAGE---' in value:
+            value = self.__decrypt_value(value)
+        return value
+    
+    def __decrypt_value(self, encrypted_string):
+        GNUPGHOME = 'test/tmp'
+
+        import gnupg
+        gpg = gnupg.GPG(gnupghome=GNUPGHOME)
+        gpg.encoding = 'utf-8'
+
+        decrypted_string =  gpg.decrypt(encrypted_string)
+        return yaml.safe_load(decrypted_string.data)
+
+
+
+

--- a/varstack/__init__.py
+++ b/varstack/__init__.py
@@ -97,7 +97,7 @@ class Varstack:
     """Load a YAML files and merge it into the existing configuration."""
     def __loadFile(self, filehandle):
         data = yaml.safe_load(filehandle)
-        self.data = self.__mergeData(self.data, data, 'merge', '<root>')
+        self.data = self.__mergeData(self.data, data, 'merge', '<root>')    
 
     """Merge two configuration sets."""
     def __mergeData(self, old, new, combine, keyname):
@@ -147,6 +147,13 @@ class Varstack:
     def __check_enc(self, value):
         if str(value).find('-----BEGIN PGP MESSAGE-----') == 0:
             value = self.__decrypt_value(value)
+        if type(value) == dict:
+            for key in value:
+                value[key] = self.__check_enc(value[key])
+        if type(value) == list:
+            for item in value:
+                item = self.__check_enc(item)
+
         return value
 
 

--- a/varstack/__init__.py
+++ b/varstack/__init__.py
@@ -145,7 +145,7 @@ class Varstack:
 
     """Check if a value is encrypted"""
     def __check_enc(self, value):
-        if str(value).find('-----BEGIN PGP MESSAGE-----') == 0:
+        if type(value) is str and value.find('-----BEGIN PGP MESSAGE-----') == 0:
             value = self.__decrypt_value(value)
         if type(value) == dict:
             for key in value:


### PR DESCRIPTION
I added a pgp support in varstack. So you can encrypt a dictonary in your yaml files.

```
data:
  enced_data: |
    -----BEGIN PGP MESSAGE-----
    Version: GnuPG v1.5.0 (GNU/Hurd)

    SlCIp2OH5FGLfdWHISzTvSuoPw/e4s8EurdY/rVp4zfJ/kOs6fZadzKqZG7AGWnI
    q0Npz0vb11RKAORbVMIf55lRaGIfBA2W+ddV/p17QsSJpOwO4QcnJGLS/aXr1paD
    [...]
    myL/Id+j96/hOBC1ylhz8EGSNml5GvhrstxHqRftr6S7DwZ/YM44J51kMX1ybYyf
    X25sKEqWCr9Y1IiZGWiiA+jNL1+Mdx6l4+KxBbQ/TRiHPik=
    =K731
    -----END PGP MESSAGE-----
```

becomes

```
data:
  enced_data:
    deced_data:
      data1: data
      data2: data
      data3:
        - list1
        - list2
```

This data will megred through varstack like normal data. 
You have to install an additional modul for python and the private key to decrypt the PGP message has to be on the system you running varstack.

For me it is an important feature to stay secure. I encrypt all my sensitive data and i hope you will like it too
