### PR TITLE
fixes that varstack crashes when HOME is not set

### DIFF
--- a/varstack/__init__.py
+++ b/varstack/__init__.py
@@ -24,7 +24,10 @@ class Varstack:
         self.data = {}
         self.config = config
         if not 'gnupghome' in self.config:
-            self.config['gnupghome'] = os.environ['HOME']+'/.gnupg'
+            if 'HOME' in os.environ:
+                self.config['gnupghome'] = os.environ['HOME']+'/.gnupg'
+            elif 'PWD' in os.environ:
+                self.config['gnupghome'] = os.environ['PWD']+'/.gnupg'
         if not 'datadir' in self.config:
             self.config['datadir'] = os.path.dirname(self.config_filename)+'/stack/'
 


### PR DESCRIPTION
In certain situation (eg when running varstack as part of salt) when
varstack is started via the systems init system (Ubuntus upstart in our case),
$HOME is not set. Python raising a "no such key" error isnt a good
thing:

```
2015-07-24 20:34:43,950 [salt.pillar      ][ERROR   ] Failed to load ext_pillar varstack: 'HOME'
Traceback (most recent call last):
  File "/usr/lib/pymodules/python2.7/salt/pillar/__init__.py", line 523, in ext_pillar
    key)
  File "/usr/lib/pymodules/python2.7/salt/pillar/__init__.py", line 495, in _external_pillar_data
    val)
  File "/usr/lib/pymodules/python2.7/salt/pillar/varstack_pillar.py", line 37, in ext_pillar
    vs = varstack.Varstack(config_filename=conf)
  File "build/bdist.linux-x86_64/egg/varstack/__init__.py", line 27, in __init__
    self.config['gnupghome'] = os.environ['HOME']+'/.gnupg'
  File "/usr/lib/python2.7/UserDict.py", line 23, in __getitem__
    raise KeyError(key)
KeyError: 'HOME'
```

With this PR varstack will properly load again. I consider this a critical bug fix.
