### PR TITLE
Enhance/docs for crypto

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,9 +193,11 @@ users:
 
 As you can see the 'users' hash was merged this time while now the 'repos' array/list only contains the entry from the node file.
 
+## GPG encryption for stacked data
+You can also work with encrypted data. If a value is PGP encrypted, varstack can decrypt this value (given the private key is available) and the result is itself interpreted as YAML. This means that the encrypted data can be nested but also keep in mind that for any other structe than single-line strings / integers, a proper yaml must be constructed before encryption!
 
-
-You can also work with encrypted dicts. If a value is PGP encrypted, varstack can decrypt this value if it is encrypted with one of your public keys.
+### Examples
+`cat "|\n  first line\n  second line\n\n" | *gpg encryption*` instead of just encrypting the multi-line string.
 
 ```
 ---
@@ -209,6 +211,8 @@ enc_data: |
   =+fch
   -----END PGP MESSAGE-----
 ```
+
+*please see `examples/` for more examples.*
 
 **Importent!** For this feature you have to install python-gnupg
 

--- a/README.md
+++ b/README.md
@@ -223,5 +223,7 @@ Inside this encrypted value, dicts and lists can exist. This will be parsed thro
 The default gnupgdir is '_$HOME/.gnupg_'. If you want to chose another path, put _gnupghome: PATH_TO_GNUPG_FOLDER_ inside your varstack.yaml config file
 
 
-
-
+## Running development tests
+```
+nosetests test/
+```

--- a/examples/stack/crypted.yaml
+++ b/examples/stack/crypted.yaml
@@ -18,15 +18,15 @@ encrypted_multiline_string: |
   -----BEGIN PGP MESSAGE-----
   Comment: GPGTools - https://gpgtools.org
 
-  hQEMA48F+mvaRh1fAQf/XKs+z6addEimXotPsVO39Stmti1JH0QZ2IiTXQDC1mEr
-  MG/6P6NgP7SkVQcyTeJIigHDqwK8Wo+FnkFvZtTmlVzrA4xhRCV2CIq/JUKTXWIV
-  GFIJMTU+umGtF8GQfTGB6LzfsNXYTeWLyXLyvoEcwK236TrrUNaH8cmY1JPw9GS1
-  a7Nn9uQrDtgTAcYRNdsQosXmFLz5IK0nA19oLlkNYqlH45n1NeDqvX4ATL9MOi6G
-  1DdGIsR+djpdVY9m2i6sx8V9o+KdpaRm04ntjaWBr0zp5tjXF11njPZnDvKa1KQY
-  KXS/OS/uetDunGC7PPlAnbQc+u8pBBxXbANAw8RHdNJTAfNcJmPZL+yU+YHhkmbu
-  ieAQviHcionUBCWKspKeLVVx2cn+UKPBGtfUO0T/2hK4JFaUbeyRrxBA08yspkQk
-  K+1dn0VAq3A0irbysAE4FcFAOD0=
-  =LwpJ
+  hQEMA48F+mvaRh1fAQgAul50sNNI+v4N+lFi6+4RN76whxIp3Y0xurmTmthF3jEg
+  zXLMG6xRegcit0820PpYQh6Uh12HUU3TpdFlOTSs7up7h6UC5RxYiV2nkX9sPILY
+  hM2ZNnUxtCmgATA+laCRBCVh+T52kdNS3XUieJTg64abZDBcegD+LLWZAj1dd6sT
+  UnyiG6FQcgmJJ5192ftp3V4IG9/mUTqfWeMOen0wSA8QryHPapuWBP1FJZEnoyio
+  lWKVFVtGbG9uMRJQbY77juNgu/LrIYmoxygX1JqaaCt4ry4wU0MBWMlhOr8bCc66
+  A/tjjKxDyqvDNu30uyvYqaV/1gMz1igT6BIIUNnQFdJYASFygD5Xaj1Ya4Ib1qOt
+  WkuB1i/OuVf1oHgU64gmohH7gXlbSKDy3aNfFFzukXJnzLg9oichZ0+dgT/MK34d
+  xEunhHbmwFagJ3WDLEoAsMA28NaUlGTZoA==
+  =cY94
   -----END PGP MESSAGE-----
 unencrypted_multiline_string: |
   first line

--- a/examples/stack/crypted.yaml
+++ b/examples/stack/crypted.yaml
@@ -14,6 +14,25 @@ encrypted_string: |
   -----END PGP MESSAGE-----
 unencrypted_string: very secret string
 
+encrypted_multiline_string: |
+  -----BEGIN PGP MESSAGE-----
+  Comment: GPGTools - https://gpgtools.org
+
+  hQEMA48F+mvaRh1fAQf/XKs+z6addEimXotPsVO39Stmti1JH0QZ2IiTXQDC1mEr
+  MG/6P6NgP7SkVQcyTeJIigHDqwK8Wo+FnkFvZtTmlVzrA4xhRCV2CIq/JUKTXWIV
+  GFIJMTU+umGtF8GQfTGB6LzfsNXYTeWLyXLyvoEcwK236TrrUNaH8cmY1JPw9GS1
+  a7Nn9uQrDtgTAcYRNdsQosXmFLz5IK0nA19oLlkNYqlH45n1NeDqvX4ATL9MOi6G
+  1DdGIsR+djpdVY9m2i6sx8V9o+KdpaRm04ntjaWBr0zp5tjXF11njPZnDvKa1KQY
+  KXS/OS/uetDunGC7PPlAnbQc+u8pBBxXbANAw8RHdNJTAfNcJmPZL+yU+YHhkmbu
+  ieAQviHcionUBCWKspKeLVVx2cn+UKPBGtfUO0T/2hK4JFaUbeyRrxBA08yspkQk
+  K+1dn0VAq3A0irbysAE4FcFAOD0=
+  =LwpJ
+  -----END PGP MESSAGE-----
+unencrypted_multiline_string: |
+  first line
+  second line
+  last line
+
 encrypted_yaml_list: |
   -----BEGIN PGP MESSAGE-----
   Comment: GPGTools - https://gpgtools.org

--- a/test/varstack_test.py
+++ b/test/varstack_test.py
@@ -54,6 +54,10 @@ class TestVarstackWithCrypto(object):
         assert_equal(self.evaluated['unencrypted_string'], self.evaluated['encrypted_string'])
         assert_is_instance(self.evaluated['encrypted_string'], str)
 
+    def test_evaluate_with_encrypted_multiline_string(self):
+        assert_equal(self.evaluated['unencrypted_multiline_string'], self.evaluated['encrypted_multiline_string'])
+        assert_is_instance(self.evaluated['encrypted_multiline_string'], str)
+
     def test_evaluate_with_encrypted_list(self):
         assert_equal(self.evaluated['unencrypted_yaml_list'], self.evaluated['encrypted_yaml_list'])
         assert_is_instance(self.evaluated['encrypted_yaml_list'], list)


### PR DESCRIPTION
We came across the use case in which a multi line string needs to be encrypted via gpg. The result was that the string decrypted by varstack was loosing all of its _\n_.

Actually this was not a real problem in the code but rather a flaw in the documentation. Whenever a multi line string is passed to decryption we need to make sure that it is a valid yaml data structure, as Varstack expects (for nesting reasons) it to be.

This MR enhances the documentation and also includes a new test case for this particular case.
